### PR TITLE
generate code after bumping versions

### DIFF
--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "com.mattermost.demo-plugin",
-	Version: "0.0.4",
+	Version: "0.0.5",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.demo-plugin';
-export const version = '0.0.4';
+export const version = '0.0.5';


### PR DESCRIPTION
Sigh, I forgot to generate the code after updating `plugin.json`. Fixed.