### PR TITLE
Fix i18n-extract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ endif
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage
-coverage: server/.depensure webapp/.npminstall
+coverage: webapp/.npminstall
 ifneq ($(HAS_SERVER),)
 	$(GO) test -race -coverprofile=server/coverage.txt ./server/...
 	$(GO) tool cover -html=server/coverage.txt
@@ -154,10 +154,13 @@ endif
 
 ## Extract strings for translation from the source code.
 .PHONY: i18n-extract
-i18n-extract: 
+i18n-extract:
 ifneq ($(HAS_WEBAPP),)
-	@[[ -d $(MM_UTILITIES_DIR) ]] || echo "You must clone github.com/mattermost/mattermost-utilities repo in .. to use this command"
-	@[[ -d $(MM_UTILITIES_DIR) ]] && cd $(MM_UTILITIES_DIR) && npm install && npm run babel && node mmjstool/build/index.js i18n extract-webapp --webapp-dir ../mattermost-plugin-demo/webapp
+ifeq ($(HAS_MM_UTILITIES),)
+	@echo "You must clone github.com/mattermost/mattermost-utilities repo in .. to use this command"
+else
+	cd $(MM_UTILITIES_DIR) && npm install && npm run babel && node mmjstool/build/index.js i18n extract-webapp --webapp-dir $(PWD)/webapp
+endif
 endif
 
 ## Clean removes all build artifacts.

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -28,6 +28,12 @@ HAS_WEBAPP ?= $(shell build/bin/manifest has_webapp)
 # Determine if a /public folder is in use
 HAS_PUBLIC ?= $(wildcard public/.)
 
+# Determine if the mattermost-utilities repo is present
+HAS_MM_UTILITIES ?= $(wildcard $(MM_UTILITIES_DIR)/.)
+
+# Store the current path for later use
+PWD ?= $(shell pwd)
+
 # Ensure that npm (and thus node) is installed.
 ifneq ($(HAS_WEBAPP),)
 ifeq ($(NPM),)


### PR DESCRIPTION
The old commands throws
```bash
/bin/sh: 1: [[: not found
You must clone github.com/mattermost/mattermost-utilities repo in .. to use this command
/bin/sh: 1: [[: not found
Makefile:159: recipe for target 'i18n-extract' failed
make: *** [i18n-extract] Error 127
```
on my ubuntu.

I fixed this and refactored the target a bit to make it Independent of the current working directory.

Site note: I would like to update the `Makefile` of the sample plugin with this command. Any objections?