### PR TITLE
[MM-16305] Allow posts from demo bot account in demo channel

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -25,8 +25,8 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		return post, ""
 	}
 
-	// Always allow posts by the demo plugin user.
-	if post.UserId == configuration.demoUserId {
+	// Always allow posts by the demo plugin user and demo plugin bot.
+	if post.UserId == p.botId || post.UserId == configuration.demoUserId {
 		return post, ""
 	}
 


### PR DESCRIPTION
I would like (2/5) to get rid of the demo user account, but this out of scope for this PR.

Fixes https://mattermost.atlassian.net/browse/MM-16305