### PR TITLE
Fix infinity loop of message posting

### DIFF
--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -104,8 +104,8 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	// Ignore posts by the demo plugin user.
-	if post.UserId == configuration.demoUserId {
+	// Ignore posts by the demo plugin user and demo plugin bot.
+	if post.UserId == p.botId || post.UserId == configuration.demoUserId {
 		return
 	}
 


### PR DESCRIPTION
Previously when the bot posted a message an infinity loop would occur, because in `MessageHasBeenPosted` a new message would be created.

This PR fixed this by ignoring posts from the bot account in `MessageHasBeenPosted`.