### PR TITLE
added ephemeral_override command

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -63,6 +63,8 @@ or disable the demo plugin's hooks functionality (but leave the command and weba
 The `/ephemeral` command demonstrates ephemeral interactive usage of SendEphemeralPost, 
 UpdateEphemeralPost, and DeleteEphemeralPost.
 
+The `/ephemeral_override` command demonstrates override of ephemeral posts in the webapp.
+
 The `/crash` command demonstrates crashing the plugin (and the server recovering/restarting the plugin).
 
 The `/dialog` command demonstrates [Interactive Dialogs](https://docs.mattermost.com/developer/interactive-dialogs.html). Use `/dialog help` for its usage in this demo plugin.

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	commandTriggerCrash     = "crash"
-	commandTriggerHooks     = "demo_plugin"
-	commandTriggerDialog    = "dialog"
-	commandTriggerEphemeral = "ephemeral"
+	commandTriggerCrash             = "crash"
+	commandTriggerHooks             = "demo_plugin"
+	commandTriggerDialog            = "dialog"
+	commandTriggerEphemeral         = "ephemeral"
+	commandTriggerEphemeralOverride = "ephemeral_override"
 
 	dialogElementNameNumber = "somenumber"
 	dialogElementNameEmail  = "someemail"
@@ -56,6 +57,15 @@ func (p *Plugin) registerCommands() error {
 	}
 
 	if err := p.API.RegisterCommand(&model.Command{
+		Trigger:          commandTriggerEphemeralOverride,
+		AutoComplete:     true,
+		AutoCompleteHint: "",
+		AutoCompleteDesc: "Demonstrates an ephemeral post overriden in the webapp.",
+	}); err != nil {
+		return errors.Wrapf(err, "failed to register %s command", commandTriggerEphemeralOverride)
+	}
+
+	if err := p.API.RegisterCommand(&model.Command{
 		Trigger:          commandTriggerDialog,
 		AutoComplete:     true,
 		AutoCompleteDesc: "Open an Interactive Dialog.",
@@ -89,6 +99,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		return p.executeCommandHooks(args), nil
 	case commandTriggerEphemeral:
 		return p.executeCommandEphemeral(args), nil
+	case commandTriggerEphemeralOverride:
+		return p.executeCommandEphemeralOverride(args), nil
 	case commandTriggerDialog:
 		return p.executeCommandDialog(args), nil
 
@@ -180,6 +192,17 @@ func (p *Plugin) executeCommandEphemeral(args *model.CommandArgs) *model.Command
 		},
 	}
 	_ = p.API.SendEphemeralPost(args.UserId, post)
+	return &model.CommandResponse{}
+}
+
+func (p *Plugin) executeCommandEphemeralOverride(args *model.CommandArgs) *model.CommandResponse {
+	_ = p.API.SendEphemeralPost(args.UserId, &model.Post{
+		ChannelId: args.ChannelId,
+		Message:   "test ephemeral override",
+		Props: model.StringInterface{
+			"type": "custom_demo_plugin",
+		},
+	})
 	return &model.CommandResponse{}
 }
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -198,9 +198,9 @@ func (p *Plugin) executeCommandEphemeral(args *model.CommandArgs) *model.Command
 func (p *Plugin) executeCommandEphemeralOverride(args *model.CommandArgs) *model.CommandResponse {
 	_ = p.API.SendEphemeralPost(args.UserId, &model.Post{
 		ChannelId: args.ChannelId,
-		Message:   "test ephemeral override",
+		Message:   "This is a demo of overriding an ephemeral post.",
 		Props: model.StringInterface{
-			"type": "custom_demo_plugin",
+			"type": "custom_demo_plugin_ephemeral",
 		},
 	})
 	return &model.CommandResponse{}

--- a/webapp/src/components/ephemeral_post_type.jsx
+++ b/webapp/src/components/ephemeral_post_type.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const {formatText, messageHtmlToComponent} = window.PostUtils;
+
+export default class EphemeralPostType extends React.PureComponent {
+    static propTypes = {
+        post: PropTypes.object.isRequired,
+        theme: PropTypes.object.isRequired,
+    }
+
+    render() {
+        const style = getStyle(this.props.theme);
+        const post = {...this.props.post};
+        const message = post.message || '';
+
+        const formattedText = messageHtmlToComponent(formatText(message));
+
+        return (
+            <div>
+                <pre style={style.configuration}>
+                    {formattedText}
+                </pre>
+            </div>
+        );
+    }
+}
+
+const getStyle = (theme) => ({
+    configuration: {
+        padding: '1em',
+        color: theme.centerChannelBg,
+        'font-style': 'oblique',
+        backgroundColor: theme.centerChannelColor,
+    },
+});

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -17,6 +17,7 @@ import UserActions from './components/user_actions';
 import RHSView from './components/right_hand_sidebar';
 
 import PostType from './components/post_type';
+import EphemeralPostType from './components/ephemeral_post_type';
 import {
     MainMenuMobileIcon,
     ChannelHeaderButtonIcon,
@@ -68,6 +69,7 @@ export default class DemoPlugin {
         );
 
         registry.registerPostTypeComponent('custom_demo_plugin', PostType);
+        registry.registerPostTypeComponent('custom_demo_plugin_ephemeral', EphemeralPostType);
 
         registry.registerMainMenuAction(
             <FormattedMessage


### PR DESCRIPTION
adds an `/ephemeral_override` command to demonstrate overriding an ephemeral post with the webapp using a `type` prop.

#### Links
https://github.com/mattermost/mattermost-server/issues/10797