### PR TITLE
Update README references to "mattermost-plugin-sample" to be "mattermost-plugin-starter-template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Demo Plugin ![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-demo/master.svg)
 
-This plugin demonstrates the capabilities of a Mattermost plugin. It includes the same build scripts as [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample), but implements all supported server-side hooks and registers a component for each supported client-side integration point. See [server/README.md](server/README.md) and [webapp/README.md](webapp/README.md) for more details. The plugin also doubles as a testbed for verifying plugin functionality during release testing.
+This plugin demonstrates the capabilities of a Mattermost plugin. It includes the same build scripts as [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template), but implements all supported server-side hooks and registers a component for each supported client-side integration point. See [server/README.md](server/README.md) and [webapp/README.md](webapp/README.md) for more details. The plugin also doubles as a testbed for verifying plugin functionality during release testing.
 
-Feel free to base your own plugin off this repository, removing or modifying components as needed. If you're already familiar with what plugins can do, consider starting from [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample) instead, which includes the same build framework but omits the demo implementations.
+Feel free to base your own plugin off this repository, removing or modifying components as needed. If you're already familiar with what plugins can do, consider starting from [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) instead, which includes the same build framework but omits the demo implementations.
 
 Note that this plugin is authored for Mattermost 5.2 and later, and is not compatible with earlier releases of Mattermost.
 
-For details on getting started, see [mattermost-plugin-sample](https://github.com/mattermost/mattermost-plugin-sample).
+For details on getting started, see [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template).


### PR DESCRIPTION
The `mattermost-plugin-sample` repo is being renamed to `mattermost-plugin-starter-template`. As a result, any references to the original name in documentation needs to be updated, including this repo.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14189