### PR TITLE
Update MM Version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ This plugin demonstrates the capabilities of a Mattermost plugin. It includes th
 
 Feel free to base your own plugin off this repository, removing or modifying components as needed. If you're already familiar with what plugins can do, consider starting from [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) instead, which includes the same build framework but omits the demo implementations.
 
-Note that this plugin is authored for Mattermost 5.2 and later, and is not compatible with earlier releases of Mattermost.
+Note that this plugin is authored for the Mattermost version indicated in the `min_server_version` within the [plugin.json](https://github.com/mattermost/mattermost-plugin-demo/blob/2461499b06453b7a37d9ca4aedd4d23d24089047/plugin.json#L6), and is not compatible with earlier releases of Mattermost.
 
 For details on getting started, see [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ This plugin demonstrates the capabilities of a Mattermost plugin. It includes th
 
 Feel free to base your own plugin off this repository, removing or modifying components as needed. If you're already familiar with what plugins can do, consider starting from [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template) instead, which includes the same build framework but omits the demo implementations.
 
-Note that this plugin is authored for the Mattermost version indicated in the `min_server_version` within the [plugin.json](https://github.com/mattermost/mattermost-plugin-demo/blob/2461499b06453b7a37d9ca4aedd4d23d24089047/plugin.json#L6), and is not compatible with earlier releases of Mattermost.
+Note that this plugin is authored for the Mattermost version indicated in the `min_server_version` within [plugin.json](https://github.com/mattermost/mattermost-plugin-demo/blob/2461499b06453b7a37d9ca4aedd4d23d24089047/plugin.json#L6), and is not compatible with earlier releases of Mattermost.
 
 For details on getting started, see [mattermost-plugin-starter-template](https://github.com/mattermost/mattermost-plugin-starter-template).


### PR DESCRIPTION
Updated main Readme to reference the Mattermost version of the plugin.json file to avoid reference to old versions.