### PR TITLE
MM-10982 Extend "/dialog" command to generate interactive dialog with relative callback URL

### DIFF
--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -24,6 +24,7 @@ const (
 	commandDialogHelp = "###### Interactive Dialog Slash Command Help\n" +
 		"- `/dialog` - pen an Interactive Dialog. Once submitted, user-entered input is posted back into a channel.\n" +
 		"- `/dialog no-elements` - Open an Interactive Dialog with no elements. Once submitted, user's action is posted back into a channel.\n" +
+		"- `/dialog relative-callback-url` - Open an Interactive Dialog with relative allback URL. Once submitted, user's action is posted back into a channel.\n" +
 		"- `/dialog help` - Show this help text"
 )
 
@@ -232,7 +233,13 @@ func (p *Plugin) executeCommandDialog(args *model.CommandArgs) *model.CommandRes
 		dialogRequest = model.OpenDialogRequest{
 			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("%s/plugins/%s/dialog/2", *serverConfig.ServiceSettings.SiteURL, manifest.Id),
-			Dialog:    getDialogWithoutElements(),
+			Dialog:    getDialogWithoutElements("somestate"),
+		}
+	case "relative-callback-url":
+		dialogRequest = model.OpenDialogRequest{
+			TriggerId: args.TriggerId,
+			URL:       fmt.Sprintf("/plugins/%s/dialog/2", manifest.Id),
+			Dialog:    getDialogWithoutElements("relative-callback-url"),
 		}
 	default:
 		return &model.CommandResponse{
@@ -327,7 +334,7 @@ func getDialogWithSampleElements() model.Dialog {
 	}
 }
 
-func getDialogWithoutElements() model.Dialog {
+func getDialogWithoutElements(state string) model.Dialog {
 	return model.Dialog{
 		CallbackId:     "somecallbackid",
 		Title:          "Sample Confirmation Dialog",
@@ -335,7 +342,7 @@ func getDialogWithoutElements() model.Dialog {
 		Elements:       nil,
 		SubmitLabel:    "Confirm",
 		NotifyOnCancel: true,
-		State:          "somestate",
+		State:          state,
 	}
 }
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -24,7 +24,7 @@ const (
 	commandDialogHelp = "###### Interactive Dialog Slash Command Help\n" +
 		"- `/dialog` - pen an Interactive Dialog. Once submitted, user-entered input is posted back into a channel.\n" +
 		"- `/dialog no-elements` - Open an Interactive Dialog with no elements. Once submitted, user's action is posted back into a channel.\n" +
-		"- `/dialog relative-callback-url` - Open an Interactive Dialog with relative allback URL. Once submitted, user's action is posted back into a channel.\n" +
+		"- `/dialog relative-callback-url` - Open an Interactive Dialog with relative callback URL. Once submitted, user's action is posted back into a channel.\n" +
 		"- `/dialog help` - Show this help text"
 )
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -21,6 +21,9 @@ const (
 	dialogElementNameNumber = "somenumber"
 	dialogElementNameEmail  = "someemail"
 
+	dialogStateSome                = "somestate"
+	dialogStateRelativeCallbackURL = "relativecallbackstate"
+
 	commandDialogHelp = "###### Interactive Dialog Slash Command Help\n" +
 		"- `/dialog` - pen an Interactive Dialog. Once submitted, user-entered input is posted back into a channel.\n" +
 		"- `/dialog no-elements` - Open an Interactive Dialog with no elements. Once submitted, user's action is posted back into a channel.\n" +
@@ -233,13 +236,13 @@ func (p *Plugin) executeCommandDialog(args *model.CommandArgs) *model.CommandRes
 		dialogRequest = model.OpenDialogRequest{
 			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("%s/plugins/%s/dialog/2", *serverConfig.ServiceSettings.SiteURL, manifest.Id),
-			Dialog:    getDialogWithoutElements("somestate"),
+			Dialog:    getDialogWithoutElements(dialogStateSome),
 		}
 	case "relative-callback-url":
 		dialogRequest = model.OpenDialogRequest{
 			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("/plugins/%s/dialog/2", manifest.Id),
-			Dialog:    getDialogWithoutElements("relative-callback-url"),
+			Dialog:    getDialogWithoutElements(dialogStateRelativeCallbackURL),
 		}
 	default:
 		return &model.CommandResponse{
@@ -330,7 +333,7 @@ func getDialogWithSampleElements() model.Dialog {
 		}},
 		SubmitLabel:    "Submit",
 		NotifyOnCancel: true,
-		State:          "somestate",
+		State:          dialogStateSome,
 	}
 }
 

--- a/server/http_hooks.go
+++ b/server/http_hooks.go
@@ -144,12 +144,17 @@ func (p *Plugin) handleDialog2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	suffix := ""
+	if request.State == "relative-callback-url" {
+		suffix = "from relative callback URL"
+	}
+
 	if _, appErr = p.API.CreatePost(&model.Post{
 		UserId:    p.botId,
 		ChannelId: request.ChannelId,
-		Message:   fmt.Sprintf("@%v confirmed an Interactive Dialog", user.Username),
+		Message:   fmt.Sprintf("@%v confirmed an Interactive Dialog %v", user.Username, suffix),
 	}); appErr != nil {
-		p.API.LogError("failed to post handleDialog1 message", "err", appErr.Error())
+		p.API.LogError("failed to post handleDialog2 message", "err", appErr.Error())
 		return
 	}
 

--- a/server/http_hooks.go
+++ b/server/http_hooks.go
@@ -145,7 +145,7 @@ func (p *Plugin) handleDialog2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	suffix := ""
-	if request.State == "relative-callback-url" {
+	if request.State == dialogStateRelativeCallbackURL {
 		suffix = "from relative callback URL"
 	}
 


### PR DESCRIPTION
Not mention in the ticket but it might be helpful to extend `/dialog` command to have relative callback URL when trying interactive dialog.

Note that this demo plugin may be used for end-to-end testing in the future.

Relative URL as seen in request payload:
![Screen Shot 2019-08-01 at 11 29 01 PM](https://user-images.githubusercontent.com/5334504/62307864-f640cc00-b4b6-11e9-8418-c84655fa3d44.png)

Command response once submitted:
![Screen Shot 2019-08-01 at 11 28 52 PM](https://user-images.githubusercontent.com/5334504/62307911-0fe21380-b4b7-11e9-8a6e-0663b1e7fce8.png)
