### PR TITLE
MM-15694: Illustrate plugin.DismissPostError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ require (
 	github.com/go-ldap/ldap v3.0.3+incompatible // indirect
 	github.com/hashicorp/go-hclog v0.9.2 // indirect
 	github.com/hashicorp/go-plugin v1.0.1 // indirect
+	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/mattermost/go-i18n v1.11.0 // indirect
-	github.com/mattermost/mattermost-server v5.12.0+incompatible
+	github.com/mattermost/mattermost-server v0.0.0-20190809162034-80fc9fff1b99
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,9 @@ github.com/mattermost/go-i18n v1.11.0 h1:1hLKqn/ZvhZ80OekjVPGYcCrBfMz+YxNNgqS+be
 github.com/mattermost/go-i18n v1.11.0/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible h1:FN4zK2wNig7MVVsOsGEZ+LeIq0gUcudn3LEGgbodMq8=
 github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible/go.mod h1:0kX1qa3DOpaPJyOdMLeo7TcBN0QmUszj9a/VygOhDe0=
+github.com/mattermost/mattermost-server v0.0.0-20190809162034-80fc9fff1b99 h1:ntqjecD9FHaikp5tQ2cR2rUCPHK5Po6nfzCfg8Yo0Q0=
+github.com/mattermost/mattermost-server v0.0.0-20190809162034-80fc9fff1b99/go.mod h1:uqNML+PbZTEc4SPWBu+RvG0KmC2mTOLaedNwnPOwv0I=
+github.com/mattermost/mattermost-server v5.11.1+incompatible h1:LPzKY0+2Tic/ik67qIg6VrydRCgxNXZQXOeaiJ2rMBY=
 github.com/mattermost/mattermost-server v5.12.0+incompatible h1:Glsf3vGsceqzaDa9BQfO5Wsj0cNxagwuBhy3pCN/AT0=
 github.com/mattermost/mattermost-server v5.12.0+incompatible/go.mod h1:O3Tfw/SymCK+cYdFSMjQZyP4VndjcfVeT6ZoJjglByw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
@@ -249,6 +252,7 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/satori/go.uuid v0.0.0-20180103174451-36e9d2ebbde5/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/analytics-go v2.0.1-0.20160426181448-2d840d861c32+incompatible/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
+github.com/segmentio/analytics-go v3.0.1+incompatible/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
 github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "name": "Demo Plugin",
     "description": "This plugin demonstrates the capabilities of a Mattermost plugin.",
     "version": "0.1.0",
-    "min_server_version": "5.12.0",
+    "min_server_version": "5.14.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",
@@ -45,7 +45,7 @@
                 "value": "Demoson III"
             }, {
                 "display_name": "McDemo",
-                "value": "McDemo"               
+                "value": "McDemo"
             }]
         }, {
             "key": "TextStyle",
@@ -76,7 +76,7 @@
             "type": "longtext",
             "help_text": "The message posted by the demo plugin when the secret phrase is detected.",
             "default": "Yay! The random secret string was posted!\n\nGo to the settings page for this plugin in the system console to generate a new random secret."
-        }, { 
+        }, {
             "key": "EnableMentionUser",
             "display_name": "Enable Mention User",
             "type": "bool",

--- a/server/message_hooks.go
+++ b/server/message_hooks.go
@@ -48,10 +48,10 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		p.API.SendEphemeralPost(post.UserId, &model.Post{
 			UserId:    configuration.demoUserId,
 			ChannelId: post.ChannelId,
-			Message:   "You must not talk about the demo plugin user.",
+			Message:   "Shh! You must not talk about the demo plugin user.",
 		})
 
-		return nil, "disallowing mention of demo plugin user"
+		return nil, plugin.DismissPostError
 	}
 
 	// Otherwise, allow the post through.


### PR DESCRIPTION
Tweak the `MessageWillBePosted` hook to dismiss posts that try to
at-mention the `@demo_plugin` user.

When enabled, the plugin already disallows posts in the demo plugin channel, but does so by displaying an error and causing the post to enter a retry/cancel state. It used to do that for at-mentions in any channel, but is now changed as per above.

This leverages the functionality provided by a community member in https://mattermost.atlassian.net/browse/MM-15694.