### PR TITLE
MM-17438: attach file to post

### DIFF
--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -98,7 +98,11 @@ func TestOnConfigurationChange(t *testing.T) {
 				api.On("GetTeams").Return([]*model.Team{&model.Team{Id: teamId}}, nil)
 				api.On("GetUserByUsername", mock.AnythingOfType("string")).Return(user, nil)
 				api.On("CreateTeamMember", teamId, "").Return(&model.TeamMember{}, nil)
-				api.On("GetChannelByNameForTeamName", "", "", false).Return(&model.Channel{}, nil)
+				channel := &model.Channel{
+					Id: model.NewId(),
+				}
+				api.On("GetChannelByNameForTeamName", "", "", false).Return(channel, nil)
+				api.On("UploadFile", mock.AnythingOfType("[]uint8"), channel.Id, "configuration.json").Return(&model.FileInfo{}, nil)
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 
 				return api


### PR DESCRIPTION
Plugins weren't able to successfully attach a file to a post in 5.12 because a unintentional security change. Verify that this is now working by attaching the demo plugin's configuration as a `.json` attachment to the `OnConfigChange: loading new configuration` posts it makes in the demo plugin channel.