### PR TITLE
MM-15340: dialog without trigger id

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -10,5 +10,6 @@
   "sidebar.enabled": "Enabled",
   "tooltip.message": "This is a custom tooltip from the Demo Plugin",
   "useractions.action": "Action",
-  "useractions.demo": "Demo Plugin: "
+  "useractions.demo": "Demo Plugin: ",
+  "sample.confirmation.dialog": "Sample Confirmation Dialog"
 }

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -95,7 +95,7 @@ export default class DemoPlugin {
                         submit_label: 'Confirm',
                         notify_on_cancel: true,
                         state: 'somestate',
-                    }
+                    },
                 });
             },
             <MainMenuMobileIcon/>,

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -80,6 +80,27 @@ export default class DemoPlugin {
             <MainMenuMobileIcon/>,
         );
 
+        registry.registerMainMenuAction(
+            <FormattedMessage
+                id='sample.confirmation.dialog'
+                defaultMessage='Sample Confirmation Dialog'
+            />,
+            () => {
+                window.openInteractiveDialog({
+                    dialog: {
+                        callback_id: 'somecallbackid',
+                        url: '/plugins/' + pluginId + '/dialog/2',
+                        title: 'Sample Confirmation Dialog',
+                        elements: [],
+                        submit_label: 'Confirm',
+                        notify_on_cancel: true,
+                        state: 'somestate',
+                    }
+                });
+            },
+            <MainMenuMobileIcon/>,
+        );
+
         registry.registerPostDropdownMenuAction(
             <FormattedMessage
                 id='plugin.name'


### PR DESCRIPTION
Illustrate how to invoke an interactive dialog without a trigger id, e.g. from a main menu option vs. a typical slash command interaction.

See https://mattermost.atlassian.net/browse/MM-15340