### PR TITLE
Integrate new plug.Helpers commands (Register and Execute command)

### DIFF
--- a/server/activate_hooks_test.go
+++ b/server/activate_hooks_test.go
@@ -57,11 +57,11 @@ func TestOnActivate(t *testing.T) {
 		"minimum supported version fullfiled, but RegisterCommand fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetServerVersion").Return(minimumServerVersion)
-				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(&model.AppError{})
 
 				return api
 			},
 			SetupHelpers: func(helpers *plugintest.Helpers) *plugintest.Helpers {
+				helpers.On("RegisterCommand", mock.AnythingOfType("*model.Command"), mock.AnythingOfType("plugin.CommandCallback")).Return(&model.AppError{})
 				return helpers
 			},
 			ShouldError: true,
@@ -69,7 +69,6 @@ func TestOnActivate(t *testing.T) {
 		"minimum supported version fullfiled, but GetTeams fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetServerVersion").Return(minimumServerVersion)
-				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 				api.On("GetTeams").Return(nil, &model.AppError{})
 
 				return api
@@ -83,7 +82,6 @@ func TestOnActivate(t *testing.T) {
 		"minimum supported version fullfiled, but CreatePost fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetServerVersion").Return(minimumServerVersion)
-				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 				api.On("GetTeams").Return([]*model.Team{&model.Team{Id: teamId}}, nil)
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(nil, &model.AppError{})
 
@@ -98,7 +96,6 @@ func TestOnActivate(t *testing.T) {
 		"minimum supported version fullfiled": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetServerVersion").Return(minimumServerVersion)
-				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 				api.On("GetTeams").Return([]*model.Team{&model.Team{Id: teamId}}, nil)
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 
@@ -115,7 +112,6 @@ func TestOnActivate(t *testing.T) {
 				v := semver.MustParse(minimumServerVersion)
 				require.Nil(t, v.IncrementMinor())
 				api.On("GetServerVersion").Return(v.String())
-				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 				api.On("GetTeams").Return([]*model.Team{&model.Team{Id: teamId}}, nil)
 				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -17,6 +17,7 @@ const (
 	commandTriggerDialog            = "dialog"
 	commandTriggerEphemeral         = "ephemeral"
 	commandTriggerEphemeralOverride = "ephemeral_override"
+	commandTestCallback             = "test_callback"
 
 	dialogElementNameNumber = "somenumber"
 	dialogElementNameEmail  = "someemail"
@@ -78,6 +79,18 @@ func (p *Plugin) registerCommands() error {
 		return errors.Wrapf(err, "failed to register %s command", commandTriggerDialog)
 	}
 
+	testCallback := func(args *plugin.CommandArgs, originalArgs *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+		return p.testCallback(args)
+	}
+	if err := p.Helpers.RegisterCommand(&model.Command{
+		Trigger:          commandTestCallback,
+		AutoComplete:     true,
+		AutoCompleteDesc: "Test Callback command.",
+		DisplayName:      "Demo Plugin Command",
+	}, testCallback); err != nil {
+		return errors.Wrapf(err, "failed to register %s command", commandTriggerDialog)
+	}
+
 	return nil
 }
 
@@ -107,6 +120,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		return p.executeCommandEphemeralOverride(args), nil
 	case commandTriggerDialog:
 		return p.executeCommandDialog(args), nil
+	case commandTestCallback:
+		return p.Helpers.ExecuteCommand(c, args)
 
 	default:
 		return &model.CommandResponse{
@@ -122,6 +137,19 @@ func (p *Plugin) executeCommandCrash() *model.CommandResponse {
 		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 		Text:         "Crashing plugin",
 	}
+}
+
+func (p *Plugin) testCallback(args *plugin.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	var text string
+	if len(args.Args) > 1 {
+		text = fmt.Sprintf("Testing callback with args: %v", args)
+	} else {
+		text = fmt.Sprintf("Testing callback without args")
+	}
+	return &model.CommandResponse{
+		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		Text:         text,
+	}, nil
 }
 
 func (p *Plugin) executeCommandHooks(args *model.CommandArgs) *model.CommandResponse {

--- a/server/command_hooks.go
+++ b/server/command_hooks.go
@@ -164,7 +164,7 @@ func (p *Plugin) executeCommandEphemeral(args *plugin.CommandArgs) *model.Comman
 	siteURL := *p.API.GetConfig().ServiceSettings.SiteURL
 
 	post := &model.Post{
-		ChannelId: args.OriginalArgs.ChannelId,
+		ChannelId: args.ChannelId,
 		Message:   "test ephemeral actions",
 		Props: model.StringInterface{
 			"attachments": []*model.SlackAttachment{{
@@ -188,13 +188,13 @@ func (p *Plugin) executeCommandEphemeral(args *plugin.CommandArgs) *model.Comman
 		},
 	}
 
-	_ = p.API.SendEphemeralPost(args.OriginalArgs.UserId, post)
+	_ = p.API.SendEphemeralPost(args.UserId, post)
 	return &model.CommandResponse{}
 }
 
 func (p *Plugin) executeCommandEphemeralOverride(args *plugin.CommandArgs) *model.CommandResponse {
-	_ = p.API.SendEphemeralPost(args.OriginalArgs.UserId, &model.Post{
-		ChannelId: args.OriginalArgs.ChannelId,
+	_ = p.API.SendEphemeralPost(args.UserId, &model.Post{
+		ChannelId: args.ChannelId,
 		Message:   "This is a demo of overriding an ephemeral post.",
 		Props: model.StringInterface{
 			"type": "custom_demo_plugin_ephemeral",
@@ -220,19 +220,19 @@ func (p *Plugin) executeCommandDialog(args *plugin.CommandArgs) *model.CommandRe
 		}
 	case "":
 		dialogRequest = model.OpenDialogRequest{
-			TriggerId: args.OriginalArgs.TriggerId,
+			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("%s/plugins/%s/dialog/1", *serverConfig.ServiceSettings.SiteURL, manifest.Id),
 			Dialog:    getDialogWithSampleElements(),
 		}
 	case "no-elements":
 		dialogRequest = model.OpenDialogRequest{
-			TriggerId: args.OriginalArgs.TriggerId,
+			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("%s/plugins/%s/dialog/2", *serverConfig.ServiceSettings.SiteURL, manifest.Id),
 			Dialog:    getDialogWithoutElements(dialogStateSome),
 		}
 	case "relative-callback-url":
 		dialogRequest = model.OpenDialogRequest{
-			TriggerId: args.OriginalArgs.TriggerId,
+			TriggerId: args.TriggerId,
 			URL:       fmt.Sprintf("/plugins/%s/dialog/2", manifest.Id),
 			Dialog:    getDialogWithoutElements(dialogStateRelativeCallbackURL),
 		}


### PR DESCRIPTION
Related to https://github.com/mattermost/mattermost-server/pull/11890

This is an example where I want to show how the new Plugin helper methods are integrated into a working plugin.

We've changed all the `command.RegisterCommand` and `command.ExecuteComand` by `plugin.RegisterCommand` and `plugin.ExecuteCommand`

**There is one thing left to change and is the version of mattermost-server in the go.mod file**