### PR TITLE
Added hideRHSPlugin action support to the plugin

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "name": "Demo Plugin",
     "description": "This plugin demonstrates the capabilities of a Mattermost plugin.",
     "version": "0.1.0",
-    "min_server_version": "5.14.0",
+    "min_server_version": "5.16.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -52,20 +52,16 @@ export default class DemoPlugin {
         registry.registerBottomTeamSidebarComponent(
             BottomTeamSidebar,
         );
-        const {showRHSPlugin, hideRHSPlugin} = registry.registerRightHandSidebarComponent(
+        const {toggleRHSPlugin} = registry.registerRightHandSidebarComponent(
             RHSView,
             <FormattedMessage
                 id='plugin.name'
                 defaultMessage='Demo Plugin'
             />);
 
-        let actionButtonIsActive = false;
         registry.registerChannelHeaderButtonAction(
             <ChannelHeaderButtonIcon/>,
-            () => {
-                store.dispatch(actionButtonIsActive ? hideRHSPlugin : showRHSPlugin);
-                actionButtonIsActive = !actionButtonIsActive;
-            },
+            () => store.dispatch(toggleRHSPlugin),
             <FormattedMessage
                 id='plugin.name'
                 defaultMessage='Demo Plugin'

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -52,16 +52,20 @@ export default class DemoPlugin {
         registry.registerBottomTeamSidebarComponent(
             BottomTeamSidebar,
         );
-        const {showRHSPlugin} = registry.registerRightHandSidebarComponent(
+        const {showRHSPlugin, hideRHSPlugin} = registry.registerRightHandSidebarComponent(
             RHSView,
             <FormattedMessage
                 id='plugin.name'
                 defaultMessage='Demo Plugin'
             />);
 
+        let actionButtonIsActive = false;
         registry.registerChannelHeaderButtonAction(
             <ChannelHeaderButtonIcon/>,
-            () => store.dispatch(showRHSPlugin),
+            () => {
+                store.dispatch(actionButtonIsActive ? hideRHSPlugin : showRHSPlugin);
+                actionButtonIsActive = !actionButtonIsActive;
+            },
             <FormattedMessage
                 id='plugin.name'
                 defaultMessage='Demo Plugin'


### PR DESCRIPTION
#### Summary

- Adds support for new `hideRHSPlugin `from `registerRightHandSidebarComponent `to close the right-hand sidebar

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/11893
  JIRA: https://mattermost.atlassian.net/browse/MM-17810
