### PR TITLE
MM-20749: restrict post menu nesting

### DIFF
--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -128,7 +128,7 @@ export default class DemoPlugin {
                 defaultMessage='First Item'
             />
         );
-        const sub1RegisterMenuItem = rootRegisterMenuItem(
+        rootRegisterMenuItem(
             firstItem,
             () => {
                 store.dispatch(postDropdownSubMenuAction(firstItem));
@@ -142,7 +142,7 @@ export default class DemoPlugin {
                 defaultMessage='Second Item'
             />
         );
-        sub1RegisterMenuItem(
+        rootRegisterMenuItem(
             secondItem,
             () => {
                 store.dispatch(postDropdownSubMenuAction(secondItem));


### PR DESCRIPTION
There are issues rendering nested post menu submenus in the RHS. For now, restrict to just a single level instead of arbitrary nesting.

Relates-to: https://mattermost.atlassian.net/browse/MM-20749
Relates-to: https://github.com/mattermost/mattermost-webapp/pull/4372