### PR TITLE
MM-22414: relax required server configuration

### DIFF
--- a/server/activate_hooks.go
+++ b/server/activate_hooks.go
@@ -37,7 +37,7 @@ func (p *Plugin) OnActivate() error {
 	if ok, err := p.checkRequiredServerConfiguration(); err != nil {
 		return errors.Wrap(err, "could not check required server configuration")
 	} else if !ok {
-		return errors.New("server configuration is not compatible")
+		p.API.LogError("Server configuration is not compatible")
 	}
 
 	configuration := p.getConfiguration()

--- a/server/activate_hooks_test.go
+++ b/server/activate_hooks_test.go
@@ -70,6 +70,11 @@ func TestOnActivate(t *testing.T) {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {
 				api.On("GetServerVersion").Return(minimumServerVersion)
 				api.On("GetBundlePath").Return("../", nil)
+				api.On("LogError", "Server configuration is not compatible").Return()
+				api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
+				api.On("GetTeams").Return([]*model.Team{&model.Team{Id: teamId}}, nil)
+				api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
+				api.On("GetBundlePath").Return("../", nil)
 
 				return api
 			},
@@ -78,7 +83,7 @@ func TestOnActivate(t *testing.T) {
 
 				return helpers
 			},
-			ShouldError: true,
+			ShouldError: false,
 		},
 		"minimum supported version fullfiled, but RegisterCommand fails": {
 			SetupAPI: func(api *plugintest.API) *plugintest.API {


### PR DESCRIPTION
#### Summary
Instead of hard-failing the demo plugin, just log an error when
showcasing the "required configuration" portion of the plugin. Right
now, the error message doesn't specifically call out next steps for
someone using the plugin, making it hard to use as a feature.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-22414