### PR TITLE
Add nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,18 @@ orbs:
 
 workflows:
   version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - plugin-ci/lint
+      - plugin-ci/test
+      - plugin-ci/build
   ci:
     jobs:
       - plugin-ci/lint:


### PR DESCRIPTION
#### Summary
Build the plugin every day to spot broken builds earlier. I'm 0/5 on weekly/daily. Thoughts?

#### Ticket Link
https://community.mattermost.com/core/pl/pxb4cdusbtytxdgyd3zde5fd9a