### PR TITLE
MM-24503 Adding custom route example.

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -145,3 +145,9 @@ This plugin registers two different admin console settings that are available on
 
 ![secret-message-setting](docs/admin_setting_with_title.png)
 
+## Custom routes
+
+This plugin registers two custom routes. 
+
+- `/plug/com.mattermost.demo-plugin/roottest` which brings you to a page with the text `Demo plugin route.`
+- `/<teamname>/com.mattermost.demo-plugin/teamtest` which brings you to a page with the text `Demo plugin team route.`

--- a/webapp/src/components/right_hand_sidebar/index.js
+++ b/webapp/src/components/right_hand_sidebar/index.js
@@ -1,11 +1,14 @@
 import {connect} from 'react-redux';
 
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
 import {isEnabled} from 'selectors';
 
 import RHSView from './rhs_view';
 
 const mapStateToProps = (state) => ({
     enabled: isEnabled(state),
+    team: getCurrentTeam(state),
 });
 
 export default connect(mapStateToProps)(RHSView);

--- a/webapp/src/components/right_hand_sidebar/rhs_view.jsx
+++ b/webapp/src/components/right_hand_sidebar/rhs_view.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {FormattedMessage} from 'react-intl';
 
 export default class RHSView extends React.PureComponent {
+    static propTypes = {
+        team: PropTypes.object.isRequired,
+    }
+
     render() {
         return (
             <div style={style.rhs}>
@@ -22,6 +27,19 @@ export default class RHSView extends React.PureComponent {
                     id='demo.testintl'
                     defaultMessage='This is the default string'
                 />
+                <br/>
+                <br/>
+                <br/>
+                <br/>
+                {'Links for custom routes'}
+                <br/>
+                <a onClick={() => window.WebappUtils.browserHistory.push('/plug/com.mattermost.demo-plugin/roottest')}>
+                    {'/plug/com.mattermost.demo-plugin/roottest'}
+                </a>
+                <br/>
+                <a onClick={() => window.WebappUtils.browserHistory.push(`/${this.props.team.name}/com.mattermost.demo-plugin/teamtest`)}>
+                    {`/${this.props.team.name}/com.mattermost.demo-plugin/teamtest`}
+                </a>
             </div>
         );
     }

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -204,8 +204,8 @@ export default class DemoPlugin {
 
         registry.registerTranslations(getTranslations);
 
-        registry.registerNeedsTeamRoute("/teamtest", () => 'Demo plugin team route.')
-        registry.registerCustomRoute("/roottest", () => 'Demo plugin route.')
+        registry.registerNeedsTeamRoute('/teamtest', () => 'Demo plugin team route.');
+        registry.registerCustomRoute('/roottest', () => 'Demo plugin route.');
     }
 
     uninitialize() {

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -203,6 +203,9 @@ export default class DemoPlugin {
         });
 
         registry.registerTranslations(getTranslations);
+
+        registry.registerNeedsTeamRoute("/teamtest", () => 'Demo plugin team route.')
+        registry.registerCustomRoute("/roottest", () => 'Demo plugin route.')
     }
 
     uninitialize() {


### PR DESCRIPTION
#### Summary
Adding example of route registration added in: https://github.com/mattermost/mattermost-webapp/pull/5367

Routes can be found at:
- `/plug/com.mattermost.demo-plugin/roottest`
- `/<teamname>/com.mattermost.demo-plugin/teamtest`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24503