### PR TITLE
Bump version to v0.8.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-demo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
     "icon_path": "assets/icon.svg",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "min_server_version": "5.24.0",
     "server": {
         "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
     "icon_path": "assets/icon.svg",
     "version": "0.8.0",
-    "min_server_version": "5.24.0",
+    "min_server_version": "5.26.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -19,7 +19,7 @@ const manifestStr = `
   "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
   "icon_path": "assets/icon.svg",
   "version": "0.8.0",
-  "min_server_version": "5.24.0",
+  "min_server_version": "5.26.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -18,7 +18,7 @@ const manifestStr = `
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-demo",
   "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
   "icon_path": "assets/icon.svg",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "min_server_version": "5.24.0",
   "server": {
     "executables": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -9,7 +9,7 @@ const manifest = JSON.parse(`
     "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
     "icon_path": "assets/icon.svg",
     "version": "0.8.0",
-    "min_server_version": "5.24.0",
+    "min_server_version": "5.26.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -8,7 +8,7 @@ const manifest = JSON.parse(`
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-demo",
     "support_url": "https://github.com/mattermost/mattermost-plugin-demo/issues",
     "icon_path": "assets/icon.svg",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "min_server_version": "5.24.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Cut a new release for `5.26` RC testing. Not much to review: https://github.com/mattermost/mattermost-plugin-demo/compare/16c47d26aaa33eeedd199237d6a679608dfb4977...master. https://github.com/mattermost/mattermost-plugin-demo/pull/105 is the only meaningful change.