### PR TITLE
[MM-31344] Adjust tooltip to match user theme

### DIFF
--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -32,7 +32,7 @@ export default class LinkTooltip extends React.PureComponent {
 }
 
 const getStyle = (theme) => ({
-        configuration: {
+    configuration: {
         borderRadius: '4px',
         boxShadow: 'rgba(61, 60, 64, 0.1) 0px 17px 50px 0px, rgba(61, 60, 64, 0.1) 0px 12px 15px 0px',
         fontSize: '14px',

--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -5,6 +5,7 @@ import {FormattedMessage} from 'react-intl';
 export default class LinkTooltip extends React.PureComponent {
     static propTypes = {
         href: PropTypes.string.isRequired,
+        theme: PropTypes.object.isRequired,
     }
 
     render() {
@@ -12,9 +13,10 @@ export default class LinkTooltip extends React.PureComponent {
             return null;
         }
 
+        const style = getStyle(this.props.theme);
         return (
             <div
-                style={parentDivStyles}
+                style={style.configuration}
             >
                 <i
                     style={iconStyles}
@@ -29,15 +31,29 @@ export default class LinkTooltip extends React.PureComponent {
     }
 }
 
-const parentDivStyles = {
-    backgroundColor: '#ffffff',
-    borderRadius: '4px',
-    boxShadow: 'rgba(61, 60, 64, 0.1) 0px 17px 50px 0px, rgba(61, 60, 64, 0.1) 0px 12px 15px 0px',
-    fontSize: '14px',
-    marginTop: '10px',
-    padding: '10px 15px 15px',
-};
+const getStyle = (theme) => ({
+        configuration: {
+        borderRadius: '4px',
+        boxShadow: 'rgba(61, 60, 64, 0.1) 0px 17px 50px 0px, rgba(61, 60, 64, 0.1) 0px 12px 15px 0px',
+        fontSize: '14px',
+        marginTop: '10px',
+        padding: '10px 15px 15px',
+        border: `1px solid ${hexToRGB(theme.centerChannelColor, '0.16')}`,
+        color: theme.centerChannelColor,
+        backgroundColor: theme.centerChannelBg,
+    },
+});
 
 const iconStyles = {
     paddingRight: '5px',
+};
+
+export const hexToRGB = (hex, alpha) => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    if (alpha) {
+        return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+    }
+    return 'rgb(' + r + ', ' + g + ', ' + b + ')';
 };


### PR DESCRIPTION
#### Summary
This PR adjusts the ToolTip theme to match the user-specified theme.  I kept the styling the same except for 
* border: `1px solid ${hexToRGB(theme.centerChannelColor, '0.16')}`
* color: `theme.centerChannelColor`
* backgroundColor: `theme.centerChannelBg`

I also tool the border and hexToRGB function from the github plugin.

##### Light colored theme
before 
<img width="638" alt="jfrerich-sysadmin 0 Update your status 354 PM" src="https://user-images.githubusercontent.com/7575921/126231631-fb5c13f3-344a-4da0-93a6-f45f16d16308.png">

after 
<img width="523" alt="jfrerich-sysadmin © Update yours" src="https://user-images.githubusercontent.com/7575921/126231636-56cc129f-6c31-4f6a-a94c-2695bac4a22d.png">

##### Dark colored theme:
before 
<img width="562" alt="jfrerich-sysadmin © Update your status 354 PM" src="https://user-images.githubusercontent.com/7575921/126231643-80f1959f-873d-4854-ab11-b4985cf0365f.png">

after 
<img width="498" alt="www test com" src="https://user-images.githubusercontent.com/7575921/126231655-24add720-4f21-411b-b8a2-bf576bac5bad.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31344