### PR TITLE
Fix nil pointer in ConfigurationWillBeSaved

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -288,6 +288,10 @@ func (p *Plugin) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, 
 		return nil, nil
 	}
 
+	if cfg == nil {
+		return newCfg, nil
+	}
+
 	invalidUsernameUsed := cfg.Username == "invalid"
 	replaceUsernameUsed := cfg.Username == "replaceme"
 


### PR DESCRIPTION
#### Summary

When the demo plugin's config is first saved, the `ConfigurationWillBeSaved` hook is called. In this first call, there is no config saved for the demo plugin at config.json's `PluginSettings.Plugins`. This causes a nil pointer in this hook as the plugin assumes it's defined.

This PR makes it so we return successfully in the case that this is the first config save for the plugin's installation.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-57423