### PR TITLE
Fix invalid parameter for openInteractiveDialog

### DIFF
--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -102,9 +102,9 @@ export default class DemoPlugin {
             />,
             () => {
                 window.openInteractiveDialog({
+                    url: '/plugins/' + manifest.id + '/dialog/2',
                     dialog: {
                         callback_id: 'somecallbackid',
-                        url: '/plugins/' + manifest.id + '/dialog/2',
                         title: 'Sample Confirmation Dialog',
                         elements: [],
                         submit_label: 'Confirm',


### PR DESCRIPTION
#### Summary
This PR fix the issue that interactive dialog opened from main menu doesn't work fine.

[screen.webm](https://github.com/mattermost/mattermost-plugin-demo/assets/1453749/9639bc2c-6e68-4958-95fa-7a476cfdeb2b)

#### Ticket Link
N/A