### PR TITLE
docs: add PULL_REQUEST_TEMPLATE.md for consistent PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!-- Thank you for contributing a pull request! Here are a few tips to help you:
+
+1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
+2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
+3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
+-->
+
+#### Summary
+<!--
+A clear, concise description of what this pull request does and why it is needed.
+-->
+
+#### Changes
+<!--
+Bullet list of changes. Be specific about the files, hooks, components, or APIs affected (server/webapp/build/CI).
+-->
+
+#### Ticket Link
+<!--
+Link the relevant GitHub issue or JIRA ticket, e.g.
+
+  Fixes https://github.com/mattermost/mattermost-plugin-demo/issues/XXXXX
+
+If there is no related ticket, leave this section empty.
+-->
+
+#### Release Notes
+<!--
+For user-facing changes include a release note using the fenced block:
+
+```release-note
+Description of the change for the release notes.
+```
+
+For non-user-facing changes (refactors, tests, docs, CI), use:
+
+```release-note-none
+```
+-->
+
+#### Screenshots
+<!--
+If the change affects the UI or any visible behavior, attach screenshots or GIFs.
+-->
+
+#### Testing
+<!--
+Describe how this was tested. Include manual steps and/or the automated tests added or updated.
+-->
+
+#### Checklist
+- [ ] Changes follow the project's code style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated (if applicable)
+- [ ] New tests added / existing tests updated (if applicable)
+- [ ] All existing tests pass (`make test` / `make test-server` / `make test-webapp`)
+- [ ] Release notes included (or `release-note-none`)


### PR DESCRIPTION
#### Summary

Adds a `.github/PULL_REQUEST_TEMPLATE.md` tailored for plugin contributions. The Mattermost org-level template at [`mattermost/.github`](https://github.com/mattermost/.github/blob/master/PULL_REQUEST_TEMPLATE.md) covers only **Summary** and **Ticket Link**. Plugin PRs are consistently asked for **Release Notes**, **Testing steps**, and a **self-review checklist**, which this template adds while preserving the org-level preamble and the `####` heading style.

As suggested by @avasconcelos114 in [#1035 (mattermost-plugin-github)](https://github.com/mattermost/mattermost-plugin-github/pull/1035), since `mattermost-plugin-demo` is the source-of-truth for plugin-specific overrides, this is the appropriate place to introduce a plugin-optimized PR template that all plugin repos can inherit from.

#### Changes
- Added `.github/PULL_REQUEST_TEMPLATE.md` with sections:
  - Summary (what and why)
  - Changes (bullet list — server/webapp/build/CI affected)
  - Ticket Link (GitHub issue or JIRA, same format as org-level)
  - Release Notes (`release-note` / `release-note-none` fenced blocks)
  - Screenshots
  - Testing (manual steps and/or automated tests)
  - Checklist (style, self-review, docs, tests, `make test*`, release notes)
- Preserved the org-level preamble (contribution checklist + submitting great PRs links) so contributors keep seeing it
- Used `####` headings to match the org-level template style

#### Ticket Link

No specific issue — developer experience improvement. Originally proposed in https://github.com/mattermost/mattermost-plugin-github/pull/1035 and redirected here per maintainer guidance.

```release-note-none
```

#### Testing
- Verified the file renders correctly when opening a test PR from the fork
- Template follows the Mattermost contribution patterns observed in the org-level `PULL_REQUEST_TEMPLATE.md`

#### Checklist
- [x] Changes follow the project's code style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] New tests added / existing tests updated (if applicable)
- [x] All existing tests pass
- [x] Release notes included (or `release-note-none`)