### PR TITLE
Fix four known bugs in demo plugin

### DIFF
--- a/server/http_hooks.go
+++ b/server/http_hooks.go
@@ -234,10 +234,15 @@ func (p *Plugin) handleDialog2(w http.ResponseWriter, r *http.Request) {
 		suffix = "from relative callback URL"
 	}
 
+	msg := "@%v confirmed an Interactive Dialog %v"
+	if request.Cancelled {
+		msg = "@%v canceled an Interactive Dialog %v"
+	}
+
 	if _, appErr = p.API.CreatePost(&model.Post{
 		UserId:    p.botID,
 		ChannelId: request.ChannelId,
-		Message:   fmt.Sprintf("@%v confirmed an Interactive Dialog %v", user.Username, suffix),
+		Message:   fmt.Sprintf(msg, user.Username, suffix),
 	}); appErr != nil {
 		p.API.LogError("Failed to post handleDialog2 message", "err", appErr.Error())
 		return

--- a/webapp/src/components/left_sidebar_header/left_sidebar_header.jsx
+++ b/webapp/src/components/left_sidebar_header/left_sidebar_header.jsx
@@ -21,7 +21,10 @@ export default class LeftSidebarHeader extends React.PureComponent {
         };
 
         return (
-            <div style={style}>
+            <div
+                style={style}
+                data-testid='demo-plugin-hook-status'
+            >
                 <i
                     className='icon fa fa-plug'
                     style={iconStyle}

--- a/webapp/src/components/right_hand_sidebar/rhs_view.jsx
+++ b/webapp/src/components/right_hand_sidebar/rhs_view.jsx
@@ -12,15 +12,15 @@ export default function RHSView({team, channel}) {
     // useEffect example: automatically pop out the RHS when autoPopout is toggled on
     useEffect(() => {
         if (autoPopout) {
-            if (popoutSupported) {
+            if (popoutSupported && team && channel) {
                 window.WebappUtils.popouts.popoutRhsPlugin('Demo Plugin', pluginId, team.name, channel.name);
             }
             setAutoPopout(false);
         }
-    }, [autoPopout, popoutSupported, team.name, channel.name]);
+    }, [autoPopout, popoutSupported, team?.name, channel?.name]);
 
     const handlePopout = () => {
-        if (popoutSupported) {
+        if (popoutSupported && team && channel) {
             window.WebappUtils.popouts.popoutRhsPlugin('Demo Plugin', pluginId, team.name, channel.name);
         }
     };
@@ -53,8 +53,8 @@ export default function RHSView({team, channel}) {
                 {'/plug/com.mattermost.demo-plugin/roottest'}
             </a>
             <br/>
-            <a onClick={() => window.WebappUtils.browserHistory.push(`/${team.name}/com.mattermost.demo-plugin/teamtest`)}>
-                {`/${team.name}/com.mattermost.demo-plugin/teamtest`}
+            <a onClick={() => team && window.WebappUtils.browserHistory.push(`/${team.name}/com.mattermost.demo-plugin/teamtest`)}>
+                {`/${team?.name}/com.mattermost.demo-plugin/teamtest`}
             </a>
             <br/>
             <br/>

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -102,6 +102,7 @@ export default class DemoPlugin {
             />,
             () => {
                 window.openInteractiveDialog({
+                    trigger_id: 'demo-plugin-confirmation-dialog',
                     url: '/plugins/' + manifest.id + '/dialog/2',
                     dialog: {
                         callback_id: 'somecallbackid',


### PR DESCRIPTION
Fixed 4 minor bugs with Demo plugin that were found while adding Playwright test coverage.

- Add null guards for team and channel name in rhs_view.jsx — missing values were causing a webapp crash in the pop-out tab
- Add trigger_id to openInteractiveDialog to prevent the dialog from being lost in Redux
- Add unique cancel/confirm handling in handleDialog2 with distinct messages for each outcome
- Add `data-testid` to left sidebar header hook status element

