### PR TITLE
Extract demo user/channel setup out of OnConfigurationChange

### DIFF
--- a/server/activate_hooks.go
+++ b/server/activate_hooks.go
@@ -36,7 +36,7 @@ func (p *Plugin) onActivateCore() error {
 		return errors.Wrap(err, "server configuration is not compatible")
 	}
 
-	if err := p.OnConfigurationChange(); err != nil {
+	if err := p.ensureDemoUserAndChannels(); err != nil {
 		return err
 	}
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -239,11 +239,15 @@ func (p *Plugin) diffConfiguration(newConfiguration *configuration) {
 	}
 }
 
-// OnConfigurationChange is invoked when configuration changes may have been made.
+// ensureDemoUserAndChannels loads the plugin configuration and ensures the
+// configured demo user, demo bot and demo channels exist for use by the plugin.
 //
-// This demo implementation ensures the configured demo user and channel are created for use
-// by the plugin.
-func (p *Plugin) OnConfigurationChange() error {
+// This is separate from OnConfigurationChange because creating the demo user,
+// bot and channels is not a configuration change: it is setup work that also
+// needs to happen on activation (see onActivateCore). Keeping it in its own
+// function makes that intent explicit and lets both callers share it without
+// semantically abusing the OnConfigurationChange hook.
+func (p *Plugin) ensureDemoUserAndChannels() error {
 	if p.client == nil {
 		p.client = pluginapi.NewClient(p.API, p.Driver)
 	}
@@ -280,6 +284,18 @@ func (p *Plugin) OnConfigurationChange() error {
 	p.diffConfiguration(configuration)
 
 	p.setConfiguration(configuration)
+
+	return nil
+}
+
+// OnConfigurationChange is invoked when configuration changes may have been made.
+//
+// This demo implementation ensures the configured demo user and channel are created for use
+// by the plugin.
+func (p *Plugin) OnConfigurationChange() error {
+	if err := p.ensureDemoUserAndChannels(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #110

As suggested by @larkox in https://github.com/mattermost/mattermost-plugin-demo/pull/109#discussion_r436619381, the plugin was calling `OnConfigurationChange` from `onActivateCore` purely as a way to ensure the demo user, bot and channels exist on activation - semantically, no configuration change is happening there.

This PR extracts that logic into its own `ensureDemoUserAndChannels()` function:

- `onActivateCore` now calls `ensureDemoUserAndChannels()` directly
- `OnConfigurationChange()` delegates to the same function, preserving existing behavior for real config changes
- Added a doc comment explaining why the function exists separately from the hook

Behavior is unchanged; this is a pure refactor for clarity. `go build`, `go vet` and `go test ./server/` all pass.